### PR TITLE
Fix the (de)compress bitflip in CLI util

### DIFF
--- a/src/bin/jan.rs
+++ b/src/bin/jan.rs
@@ -33,8 +33,8 @@ fn main() {
         CLIFlavor::Bit16LE => Flavor::Symbol16LE,
     };
     if args.decompress {
-        compress(flavor, r, w).unwrap()
-    } else {
         decompress(flavor, r, w).unwrap()
+    } else {
+        compress(flavor, r, w).unwrap()
     }
 }


### PR DESCRIPTION
This was introduced in 9395f6176b4e876ec5685bff58c65482191ca29a. Fixes #8.

@funny-falcon, can you verify that this fixes the issue?